### PR TITLE
feat: add user-agent header

### DIFF
--- a/src/portkey-provider.ts
+++ b/src/portkey-provider.ts
@@ -10,6 +10,8 @@ import {
 import { FetchFunction } from "@ai-sdk/provider-utils";
 import { Portkey } from "portkey-ai";
 import { defaultHeadersBuilder } from "./utils";
+import { withUserAgentSuffix } from "./utils";
+import { VERSION } from "./version";
 import {
   LanguageModelV1,
   ProviderV1,
@@ -56,7 +58,7 @@ export function createPortkey(
 ): Omit<PortkeyProvider, "chat" | "completions"> {
   const portkeyProvider = new Portkey(options) as PortkeyProvider;
 
-  const headers = defaultHeadersBuilder(portkeyProvider);
+  const headers = withUserAgentSuffix(defaultHeadersBuilder(portkeyProvider), `ai-sdk-provider/${VERSION}`);
   const getHeaders = () => headers;
 
   const getCommonModelConfig = (modelType: string): CommonModelConfig => ({

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -55,3 +55,35 @@ export async function fetchImageAsBase64(url: string): Promise<string> {
         return btoa(binary);
     }
 }
+
+/**
+ * Removes entries from a record where the value is null or undefined.
+ * @param record - The input object whose entries may be null or undefined.
+ * @returns A new object containing only entries with non-null and non-undefined values.
+ */
+export function removeUndefinedEntries<T>(
+    record: Record<string, T | undefined>,
+  ): Record<string, T> {
+    return Object.fromEntries(
+      Object.entries(record).filter(([, value]) => value !== null),
+    ) as Record<string, T>
+  }
+
+export function withUserAgentSuffix(
+headers: HeadersInit | Record<string, string | undefined> | undefined,
+...userAgentSuffixParts: string[]
+): Record<string, string> {
+const cleanedHeaders = removeUndefinedEntries(
+    (headers as Record<string, string | undefined>) ?? {},
+)
+
+const currentUserAgentHeader = cleanedHeaders['user-agent'] || ''
+const newUserAgent = [currentUserAgentHeader, ...userAgentSuffixParts]
+    .filter(Boolean)
+    .join(' ')
+
+return {
+    ...cleanedHeaders,
+    'user-agent': newUserAgent,
+}
+}

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,0 +1,3 @@
+declare const __PACKAGE_VERSION__: string | undefined
+export const VERSION: string =
+  __PACKAGE_VERSION__ === undefined ? '0.0.0-test' : __PACKAGE_VERSION__

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,10 +1,17 @@
 import { defineConfig } from 'tsup';
+import { readFileSync } from 'node:fs' 
 
+const package_ = JSON.parse(
+  readFileSync(new URL('package.json', import.meta.url), 'utf8'),
+)
 export default defineConfig([
   {
     entry: ['src/index.ts'],
     format: ['cjs', 'esm'],
     dts: true,
     sourcemap: true,
+    define: {
+      __PACKAGE_VERSION__: JSON.stringify(package_.version),
+    },
   },
 ]);

--- a/vitest.edge.config.js
+++ b/vitest.edge.config.js
@@ -1,4 +1,5 @@
 import { defineConfig } from "vite";
+import packageJson from "./package.json";
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -6,5 +7,8 @@ export default defineConfig({
     environment: "edge-runtime",
     globals: true,
     include: ["**/*.test.ts", "**/*.test.tsx"],
+  },
+  define: {
+    __PACKAGE_VERSION__: JSON.stringify(packageJson.version),
   },
 });

--- a/vitest.node.config.js
+++ b/vitest.node.config.js
@@ -1,4 +1,5 @@
 import { defineConfig } from "vite";
+import packageJson from "./package.json";
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -6,5 +7,8 @@ export default defineConfig({
     environment: "node",
     globals: true,
     include: ["**/*.test.ts", "**/*.test.tsx"],
+  },
+  define: {
+    __PACKAGE_VERSION__: JSON.stringify(packageJson.version),
   },
 });


### PR DESCRIPTION
We have started to add package versions of providers we support in AI-SDK. This change is to ensure we pass the provider version of Portkey-AI too when someones uses it.

See pull https://github.com/vercel/ai/pull/8703 for more information.

Let me know if any questions!